### PR TITLE
Fix coordinates for click commands on macOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -269,14 +269,6 @@ exports.setEditorState = (text, cursor, cursorEnd) => {
 };
 
 exports.setMouseLocation = (x, y) => {
-  if (x < 0) {
-    x = 0;
-  }
-
-  if (y < 0) {
-    y = 0;
-  }
-
   return lib.setMouseLocation(x, y);
 };
 

--- a/src/mac.cpp
+++ b/src/mac.cpp
@@ -456,12 +456,20 @@ std::tuple<std::string, int, bool> GetEditorStateFallback() {
 
 std::tuple<int, int> GetMouseLocation() {
   std::tuple<int, int> result;
-  CGFloat y = NSEvent.mouseLocation.y;
-  if (NSScreen.mainScreen != nil) {
-    y = NSScreen.mainScreen.frame.size.height - y;
-  }
-
   std::get<0>(result) = NSEvent.mouseLocation.x;
+
+  NSScreen *smallestScreen = NSScreen.mainScreen;
+  NSEnumerator *screens = [NSScreen.screens objectEnumerator];
+  NSScreen *screen;
+  while ((screen = screens.nextObject)){
+    if (screen.frame.size.height <= smallestScreen.frame.size.height) {
+      smallestScreen = screen;
+    }
+  };
+  CGFloat y = NSEvent.mouseLocation.y;
+  if (smallestScreen != nil) {
+    y = smallestScreen.frame.size.height - y;
+  }
   std::get<1>(result) = y;
   return result;
 }


### PR DESCRIPTION
Fixes an issue where raw `click` commands sometimes moved the cursor incorrectly on mac by using the correct screen's height to calculate the coordinate.