### PR TITLE
Set error if active app is App Store version of Slack

### DIFF
--- a/src/mac.cpp
+++ b/src/mac.cpp
@@ -314,14 +314,14 @@ bool ActiveApplicationIsSandboxed() {
   if (SecStaticCodeCreateWithPath((__bridge CFURLRef)bundleURL, kSecCSDefaultFlags, &staticCode) == errSecSuccess) {
     if (SecStaticCodeCheckValidityWithErrors(staticCode, kSecCSBasicValidateOnly, NULL, NULL) == errSecSuccess) {
       SecRequirementRef sandboxRequirement;
-      if (SecRequirementCreateWithString(CFSTR("entitlement[\"com.apple.security.app-sandbox\"] exists"), kSecCSDefaultFlags,
-                                    &sandboxRequirement) == errSecSuccess)
+      if (SecRequirementCreateWithString(CFSTR("entitlement[\"com.apple.security.app-sandbox\"] exists"), kSecCSDefaultFlags, &sandboxRequirement) == errSecSuccess)
       {
         OSStatus codeCheckResult = SecStaticCodeCheckValidityWithErrors(staticCode, kSecCSBasicValidateOnly, sandboxRequirement, NULL);
         if (codeCheckResult == errSecSuccess) {
             isSandboxed = true;
         }
       }
+      CFRelease(sandboxRequirement);
     }
     CFRelease(staticCode);
   }

--- a/src/mac.hpp
+++ b/src/mac.hpp
@@ -13,6 +13,7 @@
 
 namespace driver {
 
+bool ActiveApplicationIsSandboxed();
 void Click(const std::string& button, int count);
 bool ClickButton(AXUIElementRef element, const std::string& button, int count);
 void ClickButton(const std::string& button, int count);


### PR DESCRIPTION
The App Store (sandboxed) version of Slack does not properly set the selected text range accessibility API that we rely on for obtaining the cursor position. This change detects if the current app is the App Store version of Slack and sets `error = True`. Any diff commands will therefore trigger opening the dictation box.