### PR TITLE
Editor state improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,8 +85,8 @@ exports.getEditorState = () => {
   return lib.getEditorState();
 };
 
-exports.getEditorStateFallback = () => {
-  return lib.getEditorStateFallback();
+exports.getEditorStateFallback = (paragraph) => {
+  return lib.getEditorStateFallback(!!paragraph);
 };
 
 exports.getInstalledApplications = async () => {
@@ -219,6 +219,10 @@ exports.pressKey = (key, modifiers, count) => {
 };
 
 exports.quitApplication = async (application, aliases) => {
+  if (!application) {
+    return;
+  }
+
   if (
     applicationMatches(application, await exports.getRunningApplications(), aliases).length == 0
   ) {
@@ -233,6 +237,7 @@ exports.quitApplication = async (application, aliases) => {
   }
 
   await lib.focusApplication(application);
+  await exports.delay(100);
   return lib.pressKey(key, modifiers, 1);
 };
 

--- a/index.js
+++ b/index.js
@@ -265,6 +265,10 @@ exports.runShell = async (command, args, options) => {
   });
 };
 
+exports.select = (paragraph) => {
+  return lib.select(!!paragraph);
+};
+
 exports.setEditorState = (text, cursor, cursorEnd) => {
   if (!cursorEnd) {
     cursorEnd = 0;

--- a/index.js
+++ b/index.js
@@ -265,10 +265,6 @@ exports.runShell = async (command, args, options) => {
   });
 };
 
-exports.select = (paragraph) => {
-  return lib.select(!!paragraph);
-};
-
 exports.setEditorState = (text, cursor, cursorEnd) => {
   if (!cursorEnd) {
     cursorEnd = 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serenade-driver",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "A library for cross-platform system automations.",
   "main": "index.js",
   "repository": "https://github.com/serenadeai/driver",

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -126,13 +126,16 @@ Napi::Promise GetEditorStateFallback(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   Napi::Promise::Deferred deferred = Napi::Promise::Deferred::New(env);
 
+  bool paragraph = info[0].As<Napi::Boolean>().Value();
+
 #ifdef __linux__
   Display* display = XOpenDisplay(NULL);
   std::tuple<std::string, int, bool> state =
-      driver::GetEditorStateFallback(display);
+      driver::GetEditorStateFallback(display, paragraph);
   XCloseDisplay(display);
 #else
-  std::tuple<std::string, int, bool> state = driver::GetEditorStateFallback();
+  std::tuple<std::string, int, bool> state =
+      driver::GetEditorStateFallback(paragraph);
 #endif
 
   Napi::Object result = Napi::Object::New(env);

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -245,16 +245,6 @@ Napi::Promise PressKey(const Napi::CallbackInfo& info) {
   return deferred.Promise();
 }
 
-Napi::Promise Select(const Napi::CallbackInfo& info) {
-  Napi::Env env = info.Env();
-  Napi::Promise::Deferred deferred = Napi::Promise::Deferred::New(env);
-
-  driver::Select(info[0].As<Napi::Boolean>().Value());
-
-  deferred.Resolve(env.Undefined());
-  return deferred.Promise();
-}
-
 Napi::Promise SetEditorState(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   Napi::Promise::Deferred deferred = Napi::Promise::Deferred::New(env);
@@ -331,8 +321,6 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
               Napi::Function::New(env, MouseDown));
   exports.Set(Napi::String::New(env, "mouseUp"),
               Napi::Function::New(env, MouseUp));
-  exports.Set(Napi::String::New(env, "select"),
-              Napi::Function::New(env, Select));
   exports.Set(Napi::String::New(env, "setEditorState"),
               Napi::Function::New(env, SetEditorState));
   exports.Set(Napi::String::New(env, "setMouseLocation"),

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -245,6 +245,16 @@ Napi::Promise PressKey(const Napi::CallbackInfo& info) {
   return deferred.Promise();
 }
 
+Napi::Promise Select(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::Promise::Deferred deferred = Napi::Promise::Deferred::New(env);
+
+  driver::Select(info[0].As<Napi::Boolean>().Value());
+
+  deferred.Resolve(env.Undefined());
+  return deferred.Promise();
+}
+
 Napi::Promise SetEditorState(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   Napi::Promise::Deferred deferred = Napi::Promise::Deferred::New(env);
@@ -321,6 +331,8 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
               Napi::Function::New(env, MouseDown));
   exports.Set(Napi::String::New(env, "mouseUp"),
               Napi::Function::New(env, MouseUp));
+  exports.Set(Napi::String::New(env, "select"),
+              Napi::Function::New(env, Select));
   exports.Set(Napi::String::New(env, "setEditorState"),
               Napi::Function::New(env, SetEditorState));
   exports.Set(Napi::String::New(env, "setMouseLocation"),

--- a/src/driver.hpp
+++ b/src/driver.hpp
@@ -14,6 +14,7 @@ Napi::Promise GetRunningApplications(const Napi::CallbackInfo& info);
 Napi::Promise MouseDown(const Napi::CallbackInfo& info);
 Napi::Promise MouseUp(const Napi::CallbackInfo& info);
 Napi::Promise PressKey(const Napi::CallbackInfo& info);
+Napi::Promise Select(const Napi::CallbackInfo& info);
 Napi::Promise SetEditorState(const Napi::CallbackInfo& info);
 Napi::Promise SetMouseLocation(const Napi::CallbackInfo& info);
 Napi::Promise TypeText(const Napi::CallbackInfo& info);

--- a/src/driver.hpp
+++ b/src/driver.hpp
@@ -14,7 +14,6 @@ Napi::Promise GetRunningApplications(const Napi::CallbackInfo& info);
 Napi::Promise MouseDown(const Napi::CallbackInfo& info);
 Napi::Promise MouseUp(const Napi::CallbackInfo& info);
 Napi::Promise PressKey(const Napi::CallbackInfo& info);
-Napi::Promise Select(const Napi::CallbackInfo& info);
 Napi::Promise SetEditorState(const Napi::CallbackInfo& info);
 Napi::Promise SetMouseLocation(const Napi::CallbackInfo& info);
 Napi::Promise TypeText(const Napi::CallbackInfo& info);

--- a/src/linux.cpp
+++ b/src/linux.cpp
@@ -454,6 +454,13 @@ std::string ProcessName(Display* display, Window window) {
   return path;
 }
 
+void Select(bool paragraph) {
+  PressKey(paragraph ? "up" : "home",
+           std::vector<std::string>{"control", "shift"});
+  PressKey(paragraph ? "down" : "end",
+           std::vector<std::string>{"control", "shift"});
+}
+
 void SetMouseLocation(int x, int y) {
   Display* display = XOpenDisplay(NULL);
   XWarpPointer(display, None, XDefaultRootWindow(display), 0, 0, 0, 0, x, y);

--- a/src/linux.cpp
+++ b/src/linux.cpp
@@ -454,13 +454,6 @@ std::string ProcessName(Display* display, Window window) {
   return path;
 }
 
-void Select(bool paragraph) {
-  PressKey(paragraph ? "up" : "home",
-           std::vector<std::string>{"control", "shift"});
-  PressKey(paragraph ? "down" : "end",
-           std::vector<std::string>{"control", "shift"});
-}
-
 void SetMouseLocation(int x, int y) {
   Display* display = XOpenDisplay(NULL);
   XWarpPointer(display, None, XDefaultRootWindow(display), 0, 0, 0, 0, x, y);

--- a/src/linux.cpp
+++ b/src/linux.cpp
@@ -126,19 +126,23 @@ std::tuple<std::string, int, bool> GetEditorState(Display* display) {
   return result;
 }
 
-std::tuple<std::string, int, bool> GetEditorStateFallback(Display* display) {
+std::tuple<std::string, int, bool> GetEditorStateFallback(Display* display,
+                                                          bool paragraph) {
   std::tuple<std::string, int, bool> result;
 
   unsigned long color = BlackPixel(display, DefaultScreen(display));
   Window window = XCreateSimpleWindow(display, DefaultRootWindow(display), 0, 0,
                                       1, 1, 0, color, color);
-  PressKey(display, "home", std::vector<std::string>{"control", "shift"});
+
+  PressKey(display, paragraph ? "up" : "home",
+           std::vector<std::string>{"control", "shift"});
   PressKey(display, "c", std::vector<std::string>{"control"});
   usleep(10000);
   PressKey(display, "right", std::vector<std::string>{});
   std::string left = GetClipboard(display, window);
 
-  PressKey(display, "end", std::vector<std::string>{"control", "shift"});
+  PressKey(display, paragraph ? "down" : "end",
+           std::vector<std::string>{"control", "shift"});
   PressKey(display, "c", std::vector<std::string>{"control"});
   usleep(10000);
   PressKey(display, "left", std::vector<std::string>{});

--- a/src/linux.hpp
+++ b/src/linux.hpp
@@ -26,7 +26,6 @@ void MouseUp(Display* display, const std::string& button);
 void PressKey(Display* display, std::string key,
               std::vector<std::string> modifiers);
 std::string ProcessName(Display* display, Window window);
-void Select(bool paragraph);
 void SetMouseLocation(int x, int y);
 void ToggleKey(Display* display, const std::string& key, bool down);
 void ToLower(std::string& s);

--- a/src/linux.hpp
+++ b/src/linux.hpp
@@ -13,7 +13,8 @@ std::string GetActiveApplication();
 std::vector<Window> GetAllWindows(Display* display);
 std::string GetClipboard(Display* display, Window window);
 std::tuple<std::string, int, bool> GetEditorState(Display* display);
-std::tuple<std::string, int, bool> GetEditorStateFallback(Display* display);
+std::tuple<std::string, int, bool> GetEditorStateFallback(Display* display,
+                                                          bool paragraph);
 std::tuple<int, bool, bool> GetKeycodeAndModifiers(Display* display,
                                                    const std::string& key);
 std::tuple<int, int> GetMouseLocation();

--- a/src/linux.hpp
+++ b/src/linux.hpp
@@ -26,6 +26,7 @@ void MouseUp(Display* display, const std::string& button);
 void PressKey(Display* display, std::string key,
               std::vector<std::string> modifiers);
 std::string ProcessName(Display* display, Window window);
+void Select(bool paragraph);
 void SetMouseLocation(int x, int y);
 void ToggleKey(Display* display, const std::string& key, bool down);
 void ToLower(std::string& s);

--- a/src/mac.cpp
+++ b/src/mac.cpp
@@ -423,8 +423,9 @@ std::tuple<std::string, int, bool> GetEditorState() {
   return result;
 }
 
-std::tuple<std::string, int, bool> GetEditorStateFallback() {
+std::tuple<std::string, int, bool> GetEditorStateFallback(bool paragraph) {
   std::tuple<std::string, int, bool> result;
+  std::get<2>(result) = true;
 
   NSPasteboard* pasteboard = NSPasteboard.generalPasteboard;
   [pasteboard declareTypes:@[ NSPasteboardTypeString ] owner:NULL];
@@ -433,18 +434,36 @@ std::tuple<std::string, int, bool> GetEditorStateFallback() {
     previous = [pasteboard.pasteboardItems[0] stringForType:NSPasteboardTypeString];
   }
 
-  PressKey("left", std::vector<std::string>{"command", "shift"});
-  PressKey("up", std::vector<std::string>{"command", "shift"});
+  if (paragraph) {
+    PressKey("up", std::vector<std::string>{"option", "shift"});
+  } else {
+    PressKey("left", std::vector<std::string>{"command", "shift"});
+    PressKey("up", std::vector<std::string>{"command", "shift"});
+  }
+
   PressKey("c", std::vector<std::string>{"command"});
   usleep(10000);
   PressKey("right", std::vector<std::string>{});
+
+  if (pasteboard.pasteboardItems.count == 0) {
+    return result;
+  }
   NSString* left = [pasteboard.pasteboardItems[0] stringForType:NSPasteboardTypeString];
 
-  PressKey("right", std::vector<std::string>{"command", "shift"});
-  PressKey("down", std::vector<std::string>{"command", "shift"});
+  if (paragraph) {
+    PressKey("down", std::vector<std::string>{"option", "shift"});
+  } else {
+    PressKey("right", std::vector<std::string>{"command", "shift"});
+    PressKey("down", std::vector<std::string>{"command", "shift"});
+  }
+
   PressKey("c", std::vector<std::string>{"command"});
   usleep(10000);
   PressKey("left", std::vector<std::string>{});
+
+  if (pasteboard.pasteboardItems.count == 0) {
+    return result;
+  }
   NSString* right = [pasteboard.pasteboardItems[0] stringForType:NSPasteboardTypeString];
 
   [pasteboard setString:previous forType:NSPasteboardTypeString];

--- a/src/mac.cpp
+++ b/src/mac.cpp
@@ -783,22 +783,6 @@ void SetEditorState(const std::string& text, int cursor, int cursorEnd) {
   CFRelease(rangeValue);
 }
 
-void Select(bool paragraph) {
-  if (paragraph) {
-    PressKey("up", std::vector<std::string>{"option", "shift"});
-    usleep(10000);
-    PressKey("down", std::vector<std::string>{"option", "shift"});
-    usleep(10000);
-  } else {
-    PressKey("left", std::vector<std::string>{"command", "shift"});
-    usleep(10000);
-    PressKey("up", std::vector<std::string>{"command", "shift"});
-    usleep(10000);
-    PressKey("down", std::vector<std::string>{"command", "shift"});
-    usleep(10000);
-  }
-}
-
 void SetMouseLocation(int x, int y) {
   CGEventRef event =
       CGEventCreateMouseEvent(nil, kCGEventMouseMoved, CGPointMake(x, y), kCGMouseButtonLeft);

--- a/src/mac.cpp
+++ b/src/mac.cpp
@@ -424,6 +424,7 @@ std::tuple<std::string, int, bool> GetEditorState() {
 }
 
 std::tuple<std::string, int, bool> GetEditorStateFallback(bool paragraph) {
+  long delay = 30000;
   std::tuple<std::string, int, bool> result;
   std::get<2>(result) = true;
 
@@ -436,14 +437,18 @@ std::tuple<std::string, int, bool> GetEditorStateFallback(bool paragraph) {
 
   if (paragraph) {
     PressKey("up", std::vector<std::string>{"option", "shift"});
+    usleep(delay);
   } else {
     PressKey("left", std::vector<std::string>{"command", "shift"});
+    usleep(delay);
     PressKey("up", std::vector<std::string>{"command", "shift"});
+    usleep(delay);
   }
 
   PressKey("c", std::vector<std::string>{"command"});
-  usleep(10000);
+  usleep(delay);
   PressKey("right", std::vector<std::string>{});
+  usleep(delay);
 
   if (pasteboard.pasteboardItems.count == 0) {
     return result;
@@ -452,13 +457,16 @@ std::tuple<std::string, int, bool> GetEditorStateFallback(bool paragraph) {
 
   if (paragraph) {
     PressKey("down", std::vector<std::string>{"option", "shift"});
+    usleep(delay);
   } else {
     PressKey("right", std::vector<std::string>{"command", "shift"});
+    usleep(delay);
     PressKey("down", std::vector<std::string>{"command", "shift"});
+    usleep(delay);
   }
 
   PressKey("c", std::vector<std::string>{"command"});
-  usleep(10000);
+  usleep(delay);
   PressKey("left", std::vector<std::string>{});
 
   if (pasteboard.pasteboardItems.count == 0) {
@@ -741,7 +749,7 @@ void PressKey(const std::string& key, const std::vector<std::string>& modifiers)
   ToggleKey(key, modifiers, false);
 }
 
-void SetEditorState(const std::string& source, int cursor, int cursorEnd) {
+void SetEditorState(const std::string& text, int cursor, int cursorEnd) {
   if (AXIsProcessTrustedWithOptions(NULL)) {
     return;
   }
@@ -751,14 +759,14 @@ void SetEditorState(const std::string& source, int cursor, int cursorEnd) {
     return;
   }
 
-  CFStringRef sourceValue = CFStringCreateWithCString(NULL, source.c_str(), kCFStringEncodingUTF8);
+  CFStringRef textValue = CFStringCreateWithCString(NULL, text.c_str(), kCFStringEncodingUTF8);
   CFTypeRef value = NULL;
   AXUIElementCopyAttributeValue(field, kAXValueAttribute, reinterpret_cast<CFTypeRef*>(&value));
   if (value != NULL) {
     CFRelease(value);
-    AXUIElementSetAttributeValue(field, kAXValueAttribute, sourceValue);
+    AXUIElementSetAttributeValue(field, kAXValueAttribute, textValue);
   } else {
-    AXUIElementSetAttributeValue(field, kAXTitleAttribute, sourceValue);
+    AXUIElementSetAttributeValue(field, kAXTitleAttribute, textValue);
   }
 
   int length = 0;
@@ -771,8 +779,24 @@ void SetEditorState(const std::string& source, int cursor, int cursorEnd) {
   AXUIElementSetAttributeValue(field, kAXSelectedTextRangeAttribute, rangeValue);
 
   CFRelease(field);
-  CFRelease(sourceValue);
+  CFRelease(textValue);
   CFRelease(rangeValue);
+}
+
+void Select(bool paragraph) {
+  if (paragraph) {
+    PressKey("up", std::vector<std::string>{"option", "shift"});
+    usleep(10000);
+    PressKey("down", std::vector<std::string>{"option", "shift"});
+    usleep(10000);
+  } else {
+    PressKey("left", std::vector<std::string>{"command", "shift"});
+    usleep(10000);
+    PressKey("up", std::vector<std::string>{"command", "shift"});
+    usleep(10000);
+    PressKey("down", std::vector<std::string>{"command", "shift"});
+    usleep(10000);
+  }
 }
 
 void SetMouseLocation(int x, int y) {

--- a/src/mac.cpp
+++ b/src/mac.cpp
@@ -840,6 +840,10 @@ void ToggleKey(const std::string& key, const std::vector<std::string>& modifiers
         adjustedModifiers.end()) {
       CGEventSetFlags(event, CGEventGetFlags(event) | kCGEventFlagMaskCommand);
     }
+    if (std::find(adjustedModifiers.begin(), adjustedModifiers.end(), "commandOrControl") !=
+        adjustedModifiers.end()) {
+      CGEventSetFlags(event, CGEventGetFlags(event) | kCGEventFlagMaskCommand);
+    }
     if (std::find(adjustedModifiers.begin(), adjustedModifiers.end(), "function") !=
         adjustedModifiers.end()) {
       CGEventSetFlags(event, CGEventGetFlags(event) | kCGEventFlagMaskSecondaryFn);

--- a/src/mac.hpp
+++ b/src/mac.hpp
@@ -43,7 +43,6 @@ void MouseDown(const std::string& button);
 void MouseUp(const std::string& button);
 void PressKey(const std::string& key,
               const std::vector<std::string>& modifiers);
-void Select(bool paragraph);
 void SetEditorState(const std::string& text, int cursor, int cursorEnd);
 void SetMouseLocation(int x, int y);
 void ToggleKey(const std::string& key,

--- a/src/mac.hpp
+++ b/src/mac.hpp
@@ -43,7 +43,8 @@ void MouseDown(const std::string& button);
 void MouseUp(const std::string& button);
 void PressKey(const std::string& key,
               const std::vector<std::string>& modifiers);
-void SetEditorState(const std::string& source, int cursor, int cursorEnd);
+void Select(bool paragraph);
+void SetEditorState(const std::string& text, int cursor, int cursorEnd);
 void SetMouseLocation(int x, int y);
 void ToggleKey(const std::string& key,
                const std::vector<std::string>& modifiers, bool down);

--- a/src/mac.hpp
+++ b/src/mac.hpp
@@ -27,7 +27,7 @@ void GetClickableButtons(AXUIElementRef element,
                          std::vector<std::string>& result);
 std::vector<std::string> GetClickableButtons();
 std::tuple<std::string, int, bool> GetEditorState();
-std::tuple<std::string, int, bool> GetEditorStateFallback();
+std::tuple<std::string, int, bool> GetEditorStateFallback(bool paragraph);
 std::tuple<int, int> GetMouseLocation();
 CFStringRef GetLines(AXUIElementRef element);
 CFStringRef GetLineText(AXUIElementRef element, CFMutableArrayRef textChildren);

--- a/src/windows.cpp
+++ b/src/windows.cpp
@@ -42,7 +42,8 @@ BOOL CALLBACK FocusWindow(HWND window, LPARAM data) {
       return TRUE;
     }
 
-    AttachThreadInput(GetWindowThreadProcessId(GetForegroundWindow(), NULL), GetCurrentThreadId(), true);
+    AttachThreadInput(GetWindowThreadProcessId(GetForegroundWindow(), NULL),
+                      GetCurrentThreadId(), true);
     WINDOWPLACEMENT placement;
     GetWindowPlacement(window, &placement);
     if (placement.showCmd == SW_SHOWMAXIMIZED) {
@@ -54,7 +55,8 @@ BOOL CALLBACK FocusWindow(HWND window, LPARAM data) {
     }
 
     SetForegroundWindow(window);
-    AttachThreadInput(GetWindowThreadProcessId(GetForegroundWindow(), NULL), GetCurrentThreadId(), false);
+    AttachThreadInput(GetWindowThreadProcessId(GetForegroundWindow(), NULL),
+                      GetCurrentThreadId(), false);
     return FALSE;
   }
 
@@ -395,20 +397,6 @@ void RemoveNonASCII(std::string& s) {
       s[i] = ' ';
     }
   }
-}
-
-void Select(bool paragraph) {
-  if (paragraph) {
-    PressKey("home", std::vector<std::string>{});
-    Sleep(10);
-    PressKey("end", std::vector<std::string>{"shift"});
-    Sleep(10);
-    PressKey("down", std::vector<std::string>{"control", "shift"});
-  } else {
-    PressKey("a", std::vector<std::string>{"control"});
-  }
-
-  Sleep(10);
 }
 
 void SetMouseLocation(int x, int y) { SetCursorPos(x, y); }

--- a/src/windows.cpp
+++ b/src/windows.cpp
@@ -373,6 +373,13 @@ std::string ProcessName(HWND window) {
   return std::string(wide.begin(), wide.end());
 }
 
+void Select(bool paragraph) {
+  PressKey(paragraph ? "up" : "home",
+           std::vector<std::string>{"control", "shift"});
+  PressKey(paragraph ? "down" : "end",
+           std::vector<std::string>{"control", "shift"});
+}
+
 void SetMouseLocation(int x, int y) { SetCursorPos(x, y); }
 
 void ToggleKey(const std::string& key, bool down) {

--- a/src/windows.cpp
+++ b/src/windows.cpp
@@ -54,6 +54,7 @@ BOOL CALLBACK FocusWindow(HWND window, LPARAM data) {
       ShowWindow(window, SW_NORMAL);
     }
 
+    AllowSetForegroundWindow(ASFW_ANY);
     SetForegroundWindow(window);
     AttachThreadInput(GetWindowThreadProcessId(GetForegroundWindow(), NULL),
                       GetCurrentThreadId(), false);

--- a/src/windows.cpp
+++ b/src/windows.cpp
@@ -98,17 +98,20 @@ std::tuple<std::string, int, bool> GetEditorState() {
   InitializeUIAutomation();
 
   IUIAutomationElement* focused;
-  if (automation_ == NULL || automation_->GetFocusedElement(&focused) != S_OK || focused == NULL) {
+  if (automation_ == NULL || automation_->GetFocusedElement(&focused) != S_OK ||
+      focused == NULL) {
     return result;
   }
 
   BOOL focusable = FALSE;
-  if (focused->get_CurrentIsKeyboardFocusable(&focusable) != S_OK || focusable == NULL || focusable == FALSE) {
+  if (focused->get_CurrentIsKeyboardFocusable(&focusable) != S_OK ||
+      focusable == NULL || focusable == FALSE) {
     return result;
   }
 
   BOOL focus = FALSE;
-  if (focused->get_CurrentHasKeyboardFocus(&focus) != S_OK || focus == NULL || focus == FALSE) {
+  if (focused->get_CurrentHasKeyboardFocus(&focus) != S_OK || focus == NULL ||
+      focus == FALSE) {
     return result;
   }
 
@@ -160,17 +163,19 @@ std::tuple<std::string, int, bool> GetEditorState() {
   return result;
 }
 
-std::tuple<std::string, int, bool> GetEditorStateFallback() {
+std::tuple<std::string, int, bool> GetEditorStateFallback(bool paragraph) {
   std::tuple<std::string, int, bool> result;
 
   std::string previous = GetClipboard();
-  PressKey("home", std::vector<std::string>{"control", "shift"});
+  PressKey(paragraph ? "up" : "home",
+           std::vector<std::string>{"control", "shift"});
   PressKey("c", std::vector<std::string>{"control"});
   Sleep(10);
   PressKey("right", std::vector<std::string>{});
   std::string left = GetClipboard();
 
-  PressKey("end", std::vector<std::string>{"control", "shift"});
+  PressKey(paragraph ? "down" : "end",
+           std::vector<std::string>{"control", "shift"});
   PressKey("c", std::vector<std::string>{"control"});
   Sleep(10);
   PressKey("left", std::vector<std::string>{});

--- a/src/windows.hpp
+++ b/src/windows.hpp
@@ -23,6 +23,7 @@ void MouseDown(const std::string& button);
 void MouseUp(const std::string& button);
 void PressKey(const std::string& key, std::vector<std::string> modifiers);
 std::string ProcessName(HWND window);
+void RemoveNonASCII(std::string& s);
 void Select(bool paragraph);
 void SetMouseLocation(int x, int y);
 void ToggleKey(const std::string& key, bool down);

--- a/src/windows.hpp
+++ b/src/windows.hpp
@@ -12,11 +12,12 @@ BOOL CALLBACK FocusWindow(HWND window, LPARAM data);
 std::string GetActiveApplication();
 std::string GetClipboard();
 std::tuple<std::string, int, bool> GetEditorState();
-std::tuple<std::string, int, bool> GetEditorStateFallback();
+std::tuple<std::string, int, bool> GetEditorStateFallback(bool paragraph);
 std::tuple<int, int> GetMouseLocation();
 std::vector<std::string> GetRunningApplications();
 BOOL CALLBACK GetRunningWindows(HWND window, LPARAM data);
-std::tuple<int, bool, bool, int> GetVirtualKeyAndModifiers(const std::string& key);
+std::tuple<int, bool, bool, int> GetVirtualKeyAndModifiers(
+    const std::string& key);
 void InitializeUIAutomation();
 void MouseDown(const std::string& button);
 void MouseUp(const std::string& button);

--- a/src/windows.hpp
+++ b/src/windows.hpp
@@ -23,6 +23,7 @@ void MouseDown(const std::string& button);
 void MouseUp(const std::string& button);
 void PressKey(const std::string& key, std::vector<std::string> modifiers);
 std::string ProcessName(HWND window);
+void Select(bool paragraph);
 void SetMouseLocation(int x, int y);
 void ToggleKey(const std::string& key, bool down);
 

--- a/src/windows.hpp
+++ b/src/windows.hpp
@@ -24,7 +24,6 @@ void MouseUp(const std::string& button);
 void PressKey(const std::string& key, std::vector<std::string> modifiers);
 std::string ProcessName(HWND window);
 void RemoveNonASCII(std::string& s);
-void Select(bool paragraph);
 void SetMouseLocation(int x, int y);
 void ToggleKey(const std::string& key, bool down);
 


### PR DESCRIPTION
add the ability to get just the current paragraph of the editor. remove need to press the escape key on windows after switching apps. remove extra null byte from linux application names. add a delay to quitApplication to make sure the new application is focused. fix `commandOrControl` on Mac.