### PR TITLE
ensure windows is not null before releasing

### DIFF
--- a/src/mac.cpp
+++ b/src/mac.cpp
@@ -333,14 +333,16 @@ bool ActiveApplicationIsSandboxed() {
 int GetActivePid() {
   NSArray* windows = (NSArray*)CGWindowListCopyWindowInfo(
       kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements, kCGNullWindowID);
-  for (NSDictionary* window in windows) {
-    int pid = [[window objectForKey:@"kCGWindowOwnerPID"] intValue];
-    if ([NSRunningApplication runningApplicationWithProcessIdentifier:pid].active) {
-      CFRelease(windows);
-      return pid;
+  if (windows != NULL) {
+    for (NSDictionary* window in windows) {
+      int pid = [[window objectForKey:@"kCGWindowOwnerPID"] intValue];
+      if ([NSRunningApplication runningApplicationWithProcessIdentifier:pid].active) {
+        CFRelease(windows);
+        return pid;
+      }
     }
+    CFRelease(windows);
   }
-  CFRelease(windows);
 
   NSRunningApplication* running = [NSWorkspace sharedWorkspace].frontmostApplication;
   if (running == NULL) {

--- a/src/mac.cpp
+++ b/src/mac.cpp
@@ -333,6 +333,8 @@ bool ActiveApplicationIsSandboxed() {
 int GetActivePid() {
   NSArray* windows = (NSArray*)CGWindowListCopyWindowInfo(
       kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements, kCGNullWindowID);
+  // CGWindowListCopyWindowInfo can return NULL if there is no window server running or if we
+  // are outside of a GUI security session (can happen during update + restart)
   if (windows != NULL) {
     for (NSDictionary* window in windows) {
       int pid = [[window objectForKey:@"kCGWindowOwnerPID"] intValue];


### PR DESCRIPTION
`CGWindowListCopyWindowInfo` can return NULL if there is no window server running or if we are outside of a GUI security session (can happen during update + restart). This change ensures that this is not the case before releasing the `windows` object.