### PR TITLE
Strip spaces from application paths on Mac to match behavior on Windows/Linux

### DIFF
--- a/src/mac.cpp
+++ b/src/mac.cpp
@@ -275,14 +275,14 @@ void FocusApplication(const std::string& application) {
         [NSRunningApplication runningApplicationWithProcessIdentifier:[pid intValue]];
 
     if (app.bundleURL != NULL) {
-      if ([app.bundleURL.path.lowercaseString containsString:name]) {
+      NSString* appName = [app.bundleURL.path.lowercaseString stringByReplacingOccurrencesOfString:@" " withString:@""];
+      if ([appName containsString:name]) {
         [app unhide];
         [app activateWithOptions:NSApplicationActivateIgnoringOtherApps];
         break;
       }
     }
   }
-
   CFRelease(windows);
 }
 


### PR DESCRIPTION
The client normalizes application paths by making the path all lowercase and stripping spaces. The macOS driver was not stripping spaces from process names when matching, so app names that included spaces and were not remapped to an alias by the client weren't being properly matched by the `focusApplication` method.

This was already being implemented in the Linux and Windows drivers, so no change is needed there.