### PR TITLE
Allow fullscreened apps to respond to focus commands on macOS

### DIFF
--- a/src/mac.cpp
+++ b/src/mac.cpp
@@ -344,7 +344,7 @@ bool ActiveApplicationIsSandboxed() {
 
 int GetActivePid() {
   NSArray* windows = (NSArray*)CGWindowListCopyWindowInfo(
-      kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements, kCGNullWindowID);
+      kCGWindowListOptionAll | kCGWindowListExcludeDesktopElements, kCGNullWindowID);
   // CGWindowListCopyWindowInfo can return NULL if there is no window server running or if we
   // are outside of a GUI security session (can happen during update + restart)
   if (windows != NULL) {
@@ -596,7 +596,7 @@ std::vector<std::string> GetRunningApplications() {
   std::vector<std::string> result;
   NSMutableSet* pids = [[NSMutableSet alloc] init];
   NSArray* windows = (NSArray*)CGWindowListCopyWindowInfo(
-      kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements, kCGNullWindowID);
+      kCGWindowListOptionAll | kCGWindowListExcludeDesktopElements, kCGNullWindowID);
 
   for (NSDictionary* window in windows) {
     [pids addObject:[window objectForKey:@"kCGWindowOwnerPID"]];

--- a/src/mac.cpp
+++ b/src/mac.cpp
@@ -264,7 +264,7 @@ void FocusApplication(const std::string& application) {
 
   NSMutableSet* pids = [[NSMutableSet alloc] init];
   NSArray* windows = (NSArray*)CGWindowListCopyWindowInfo(
-      kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements, kCGNullWindowID);
+      kCGWindowListOptionAll | kCGWindowListExcludeDesktopElements, kCGNullWindowID);
 
   for (NSDictionary* window in windows) {
     [pids addObject:[window objectForKey:@"kCGWindowOwnerPID"]];


### PR DESCRIPTION
Works with changes to the client to allow the Serenade window to float on top of fullscreened apps on macOS as well.