### PR TITLE
Remove typing delay on Linux

### DIFF
--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -265,7 +265,6 @@ Napi::Promise PressKey(const Napi::CallbackInfo& info) {
   for (int i = 0; i < count; i++) {
 #ifdef __linux__
     driver::PressKey(display, info[0].As<Napi::String>().Utf8Value(), modifiers);
-    usleep(100000);
 #else
     AUTORELEASE(driver::PressKey(info[0].As<Napi::String>().Utf8Value(), modifiers));
 #endif


### PR DESCRIPTION
Pretty self explanatory, see video evidence below. :smile: 

I simply removed the delay because I figure there is one in `PressKey` already anyway. And while I'm not aware of a possible reason that this was done in the first place (see [here](https://github.com/serenadeai/driver/commit/43be13514e2d7036ca195ed8b9c4556214f2678c)), I've worked with this for about an hour now without issues.


## BEFORE

https://user-images.githubusercontent.com/16936908/143286826-fd2e4712-b494-451e-848b-5ffa49794200.mp4


## AFTER

https://user-images.githubusercontent.com/16936908/143286811-c97879ee-5314-4509-8e11-ceb43c3724f6.mp4




