### PR TITLE
runShell: exclude env variables injected by serenade

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,17 @@ const path = require("path");
 const shortcut = require("windows-shortcuts");
 const lib = require("bindings")("serenade-driver.node");
 
+const cleanEnvironmentVariables = Object.fromEntries(
+  Object.entries(process.env).filter(
+    ([name]) => !([
+      "CHROME_CRASHPAD_PIPE_NAME",
+      "ELECTRON_RUN_AS_NODE",
+      "NODE_ENV",
+      "ORIGINAL_XDG_CURRENT_DESKTOP"
+    ].includes(name))
+  )
+)
+
 const applicationMatches = (application, possible, aliases) => {
   let alias = application;
   if (aliases && aliases[application]) {
@@ -270,6 +281,11 @@ exports.runShell = async (command, args, options) => {
   let stderr = "";
   if (!options) {
     options = {};
+  }
+
+  options.env = {
+    ...cleanEnvironmentVariables,
+    ...options.env
   }
 
   const spawned = child_process.spawn(command, args, options);


### PR DESCRIPTION
Took me a couple of hours to figure out that the reason why dependencies in my projects didn't install properly all of a sudden was that serenade adds `NODE_ENV=production` to the environment (among other things).

Which is obviously inherited when using `runShell`.

I think it's not reasonable for users to have to anticipate this and so I thought that I should submit this PR.

Just a suggestion of course. 😄 